### PR TITLE
Create update-upstream-relay-repo.yml

### DIFF
--- a/.github/workflows/update-upstream-relay-repo.yml
+++ b/.github/workflows/update-upstream-relay-repo.yml
@@ -1,0 +1,29 @@
+# https://stackoverflow.com/a/68213855/16672148
+name: Send submodule updates to mozilla/fx-private-relay-add-on repo
+
+on:
+  push:
+    branches: 
+      - main
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          repository: mozilla/fx-private-relay-add-on
+          token: ${{ secrets.RELAY_REPO_TOKEN }}
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This adds a new GitHub Action to this repo which will automatically update the upstream mozilla/fx-private-relay-add-on submodule every time translations are updated. This should keep the Relay add-on updated with all the latest translations.

Just like we did in https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/4, we need to ...


1. Generate a token that has write access to the fx-private-relay-add-on repo.
   * I suggest we:
      * Accept the invitation I sent to @mozilla-pontoon to join the relay add-on repo
      * generate or re-use a token that @mozilla-pontoon uses to commit directly to other repos
2. Add that token as a secret to this repo's Actions Secrets:
   * Name: `RELAY_REPO_TOKEN`
   * Value: The value from Step 1