### PR TITLE
Revise message ID to render correctly for Chrome

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -1,4 +1,7 @@
 {
+    "extensionDescription": {
+        "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+    },
     "extensionDescription_v1": {
         "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox.",
         "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."

--- a/en/messages.json
+++ b/en/messages.json
@@ -1,6 +1,6 @@
 {
-    "extensionDescription": {
-        "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+    "extensionDescription_v1": {
+        "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox.",
         "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."
     },
     "firstRunP": {

--- a/en/messages.json
+++ b/en/messages.json
@@ -1,10 +1,11 @@
 {
     "extensionDescription": {
         "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+        "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."
     },
     "extensionDescription_v1": {
         "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox.",
-        "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."
+        "description": "Shortened description of the extension. Must remain under 132 characters. DO NOT TRANSLATE \"Firefox Relay\"."
     },
     "firstRunP": {
         "message": "You’ve successfully installed the Firefox Relay add-on. To get started, sign in to Relay with your Firefox account.",

--- a/en/messages.json
+++ b/en/messages.json
@@ -59,7 +59,7 @@
     "popupSignUpPanelContinue": {
         "message": "Continue"
     },
-    "popupRemainingAliases-2": {
+    "popupRemainingAliases_2": {
         "message": "Remaining aliases: $REMAINING$",
         "description": "Tells the user how many more aliases they can make.",
         "placeholders": {


### PR DESCRIPTION
These changes are required for Chrome compatibility  of the add-on. 

- The main add-on description must be below 132 characters. 
- Any message strings need to be underscored (`_`) instead of hyphened (`-`). 