### PR TITLE
Add a pointer to Pontoon to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Localization for the Firefox Relay Premium add-on
 The application code with build instructions can be found
 at <https://github.com/mozilla/fx-private-relay-add-on>.
 
+To contribute localizations, see
+[Pontoon](https://pontoon.mozilla.org/projects/firefox-relay-add-on/).
+
 # License
 Translations in this repository are available under the
 terms of the [Mozilla Public License v2.0](https://www.mozilla.org/MPL/2.0/).


### PR DESCRIPTION
To avoid people trying to make a contribution directly through this repository, like in https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/16.