### PR TITLE
Add On Announcements New Strings (25mb, Critical Emails, Sign back in)

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -149,7 +149,7 @@
     },
     "popupAttachmentSizeIncreaseBody": {
         "message": "Firefox Relay can now forward emails up to 25MB, including attachments.",
-        "description": "DO NOT TRANSLATE \"Relay Relay\"."
+        "description": "DO NOT TRANSLATE \"Firefox Relay\"."
     },
     "popupCriticalEmailForwardingHeadline": {
         "message": "Critical email forwarding"

--- a/en/messages.json
+++ b/en/messages.json
@@ -144,6 +144,24 @@
         "message": "Relay can help you protect your email no matter where you are.",
         "description": "DO NOT TRANSLATE \"Relay\"."
     },
+    "popupAttachmentSizeIncreaseHeadline": {
+        "message": "Attachment size increase"
+    },
+    "popupAttachmentSizeIncreaseBody": {
+        "message": "Firefox Relay can now forward emails up to 25MB, including attachments."
+    },
+    "popupCriticalEmailForwardingHeadline": {
+        "message": "Critical email forwarding"
+    },
+    "popupCriticalEmailForwardingBody": {
+        "message": "Relay Premium allows you to receive only critical emails sent to an alias. You’ll receive emails like receipts but not marketing emails."
+    },
+    "popupSignBackInHeadline": {
+        "message": "Sign back in with your aliases"
+    },
+    "popupSignBackInBody": {
+        "message": "To create a new alias when you’re asked for your email, open the context menu (right-click or control-click) in an email field. From there you can create and use a new alias right away."
+    },
     "pageInputIconSignUpText": {
         "message": "Visit the Firefox Relay website to sign in or create an account.",
         "description": "In the website content icon pop-up, before a user has signed in, we tell them to sign in. DO NOT TRANSLATE \"Firefox Relay\"."

--- a/en/messages.json
+++ b/en/messages.json
@@ -148,13 +148,15 @@
         "message": "Attachment size increase"
     },
     "popupAttachmentSizeIncreaseBody": {
-        "message": "Firefox Relay can now forward emails up to 25MB, including attachments."
+        "message": "Firefox Relay can now forward emails up to 25MB, including attachments.",
+        "description": "DO NOT TRANSLATE \"Relay Relay\"."
     },
     "popupCriticalEmailForwardingHeadline": {
         "message": "Critical email forwarding"
     },
     "popupCriticalEmailForwardingBody": {
-        "message": "Relay Premium allows you to receive only critical emails sent to an alias. You’ll receive emails like receipts but not marketing emails."
+        "message": "Relay Premium allows you to receive only critical emails sent to an alias. You’ll receive emails like receipts but not marketing emails.",
+        "description": "DO NOT TRANSLATE \"Relay Premium\"."
     },
     "popupSignBackInHeadline": {
         "message": "Sign back in with your aliases"


### PR DESCRIPTION
Strings preview:

Attachment size increase:
<img width="278" alt="image" src="https://user-images.githubusercontent.com/13066134/154564904-29cf9bd0-eb57-4884-bb86-442fd76a8bdf.png">

Critical email forwarding:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/13066134/154564962-ffa4230f-ce93-4e96-a925-f0557dd950a8.png">

Signing back in with alias:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/13066134/154564987-30260c8a-f64d-4589-ba4a-d352dc7a9f8b.png">
