### PR TITLE
Uncapitalize second panel headline

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -165,6 +165,9 @@
     "popupBlockPromotionalEmailsHeadline": {
         "message": "Block Promotional Emails"
     },
+    "popupBlockPromotionalEmailsHeadline-2": {
+        "message": "Block promotional emails"
+    },
     "popupBlockPromotionalEmailsBody": {
         "message": "Enable Block Promotional Emails on an alias to stop marketing emails from reaching your inbox."
     },


### PR DESCRIPTION
Keeping the headline for the second panel consistent with the other two. 