### PR TITLE
Rename block promotional emails headline variable

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -165,7 +165,7 @@
     "popupBlockPromotionalEmailsHeadline": {
         "message": "Block Promotional Emails"
     },
-    "popupBlockPromotionalEmailsHeadline-2": {
+    "popupBlockPromotionalEmailsHeadline_2": {
         "message": "Block promotional emails"
     },
     "popupBlockPromotionalEmailsBody": {


### PR DESCRIPTION
Resolving this syntax error:
![image](https://user-images.githubusercontent.com/13066134/156201672-327eaffa-5f8e-4a88-9ded-da8db06d1dc3.png)
