### PR TITLE
Revise string title to work in non-Firefox extensions

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -165,7 +165,7 @@
     "popupBlockPromotionalEmailsHeadline": {
         "message": "Block Promotional Emails"
     },
-    "popupBlockPromotionalEmailsHeadline-2": {
+    "popupBlockPromotionalEmailsHeadline_2": {
         "message": "Block promotional emails"
     },
     "popupBlockPromotionalEmailsBody": {


### PR DESCRIPTION
The string added in https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/22 breaks when loading the add-on in Chrome. 

Note we had to do this before https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/15