### PR TITLE
Replace instances of 'alias' with 'mask', and 'domain' with 'subdomain'

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -156,23 +156,6 @@
         "message": "All email masks",
         "description": "In the pop-up panel, the use can view all masks they've created."
     },
-    "popupOnboardingPanel1Body": {
-        "message": "When the Firefox Relay icon appears on a website, select it to generate a new alias.",
-        "description": "In the pop-up panel, after the user has signed in, we tell them they can use the icon to make a new alias. DO NOT TRANSLATE \"Firefox Relay\"."
-    },
-    "popupOnboardingPanel2Headline": {
-        "message": "Don’t see the icon?"
-    },
-    "popupOnboardingPanel2Body": {
-        "message": "Right-click on form fields to access the context menu and generate an alias from there."
-    },
-    "popupOnboardingPanel3Headline": {
-        "message": "Getting too many emails?"
-    },
-    "popupOnboardingPanel3Body": {
-        "message": "Manage your Relay aliases and easily toggle Forwarding to Blocking.",
-        "description": "In the pop-up panel, after the user has signed in, we tell them they can toggle forwarding/blocking on each alias. DO NOT TRANSLATE \"Relay\"."
-    },
     "popupOnboardingMaxAliasesPanelHeadline": {
         "message": "High five!"
     },

--- a/en/messages.json
+++ b/en/messages.json
@@ -116,7 +116,7 @@
         "message": "Aliases created: $COUNT$",
         "description": "Tells the premium user how many aliases they have created.",
         "placeholders": {
-            "remaining": {
+            "count": {
                 "content": "$1"
             }
         }

--- a/en/messages.json
+++ b/en/messages.json
@@ -95,24 +95,6 @@
     "popupGetUnlimitedAliases_mask": {
         "message": "Get unlimited masks"
     },
-    "popupUnlimitedAliases": {
-        "message": "Aliases created: $COUNT$",
-        "description": "Tells the premium user how many aliases they have created.",
-        "placeholders": {
-            "count": {
-                "content": "$1"
-            }
-        }
-    },
-    "popupUnlimitedAliases_mask": {
-        "message": "Masks created: $COUNT$",
-        "description": "Tells the premium user how many masks they have created.",
-        "placeholders": {
-            "count": {
-                "content": "$1"
-            }
-        }
-    },
     "popupOnboardingShowPrevious": {
         "message": "Show previous panel"
     },

--- a/en/messages.json
+++ b/en/messages.json
@@ -3,6 +3,10 @@
         "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox.",
         "description": "Shortened description of the extension. Must remain under 132 characters. DO NOT TRANSLATE \"Firefox Relay\"."
     },
+    "extensionDescription_mask": {
+        "message": "Firefox Relay makes it easy to create email masks that forward to your true inbox.",
+        "description": "Shortened description of the extension. Must remain under 132 characters. DO NOT TRANSLATE \"Firefox Relay\"."
+    },
     "extensionDescriptionStore": {
         "message": "Firefox Relay helps you protect your real email address — the one most closely tied to your online identity. It lets you generate unique, random aliases you can use to sign up for accounts, apps, or newsletters, and forwards messages to your real address. If you find that an account is sending unwanted email or spam, you can block the alias and it will stop sending email to your inbox. Once you no longer want an account, you can delete the alias.",
         "description": "Shortened description of the extension. Must remain under 132 characters. DO NOT TRANSLATE \"Firefox Relay\"."
@@ -25,6 +29,10 @@
     },
     "firstRunPrefP": {
         "message": "Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new alias helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel.",
+        "description": "On the first run page after installing the add-on, we tell the user how interaction data helps Mozilla. DO NOT TRANSLATE \"Relay\"."
+    },
+    "firstRunPrefP_mask": {
+        "message": "Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new mask helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel.",
         "description": "On the first run page after installing the add-on, we tell the user how interaction data helps Mozilla. DO NOT TRANSLATE \"Relay\"."
     },
     "firstRunSignInButton": {
@@ -72,12 +80,33 @@
             }
         }
     },
+    "popupRemainingAliases_2_mask": {
+        "message": "Remaining masks: $REMAINING$",
+        "description": "Tells the user how many more masks they can make.",
+        "placeholders": {
+            "remaining": {
+                "content": "$1"
+            }
+        }
+    },
     "popupGetUnlimitedAliases": {
         "message": "Get unlimited aliases"
+    },
+    "popupGetUnlimitedAliases_mask": {
+        "message": "Get unlimited masks"
     },
     "popupUnlimitedAliases": {
         "message": "Aliases created: $COUNT$",
         "description": "Tells the premium user how many aliases they have created.",
+        "placeholders": {
+            "count": {
+                "content": "$1"
+            }
+        }
+    },
+    "popupUnlimitedAliases_mask": {
+        "message": "Masks created: $COUNT$",
+        "description": "Tells the premium user how many masks they have created.",
         "placeholders": {
             "count": {
                 "content": "$1"
@@ -93,22 +122,35 @@
     "ManageAllAliases": {
         "message": "Manage All Aliases"
     },
+    "ManageAllAliases_mask": {
+        "message": "Manage all masks"
+    },
     "popupOnboardingMaxAliasesPanelHeadline": {
         "message": "High five!"
     },
     "popupOnboardingMaxAliasesPanelBody": {
         "message": "You’re a Firefox Relay power user!",
-        "description": "In the pop-up panel, when a free user has hit their alias limit, we tell them they're a power-user. DO NOT TRANSLATE \"Firefox Relay\"."
+        "description": "In the pop-up panel, when a free user has hit their mask limit, we tell them they're a power-user. DO NOT TRANSLATE \"Firefox Relay\"."
     },
     "popupRegisterDomainHeadline": {
         "message": "Get a custom domain for Relay email aliases",
         "description": "DO NOT TRANSLATE \"Relay\"."
     },
+    "popupRegisterDomainHeadline_mask": {
+        "message": "Get a custom subdomain for Relay email masks",
+        "description": "DO NOT TRANSLATE \"Relay\"."
+    },
     "popupRegisterDomainButton": {
         "message": "Register email domain"
     },
+    "popupRegisterDomainButton_mask": {
+        "message": "Register email subdomain"
+    },
     "popupAliasesUsed": {
         "message": "Email aliases used"
+    },
+    "popupAliasesUsed_mask": {
+        "message": "Email masks used"
     },
     "popupEmailsBlocked": {
         "message": "Emails blocked"
@@ -141,11 +183,18 @@
         "message": "Relay Premium allows you to receive only critical emails sent to an alias. You’ll receive emails like receipts but not marketing emails.",
         "description": "DO NOT TRANSLATE \"Relay Premium\"."
     },
+    "popupCriticalEmailForwardingBody_mask": {
+        "message": "Relay Premium allows you to receive only critical emails sent to a mask. You’ll receive emails like receipts but not marketing emails.",
+        "description": "DO NOT TRANSLATE \"Relay Premium\"."
+    },
     "popupBlockPromotionalEmailsHeadline_2": {
         "message": "Block promotional emails"
     },
     "popupBlockPromotionalEmailsBody": {
         "message": "Enable Block Promotional Emails on an alias to stop marketing emails from reaching your inbox."
+    },
+    "popupBlockPromotionalEmailsBody_mask": {
+        "message": "Enable Block Promotional Emails on a mask to stop marketing emails from reaching your inbox."
     },
     "popupBlockPromotionalEmailsBodyNonPremium": {
         "message": "With Relay Premium, you can block promotional emails from reaching your inbox while still allowing you to receive emails like receipts or shipping information.",
@@ -154,8 +203,14 @@
     "popupSignBackInHeadline": {
         "message": "Sign back in with your aliases"
     },
+    "popupSignBackInHeadline_mask": {
+        "message": "Sign back in with your email masks"
+    },
     "popupSignBackInBody": {
         "message": "To create a new alias when you’re asked for your email, open the context menu (right-click or control-click) in an email field. From there you can create and use a new alias right away."
+    },
+    "popupSignBackInBody_mask": {
+        "message": "To create a new email mask when you’re asked for your email, open the context menu (right-click or control-click) in an email field. From there you can create and use a new alias right away."
     },
     "pageInputIconSignUpText": {
         "message": "Visit the Firefox Relay website to sign in or create an account.",
@@ -168,25 +223,44 @@
     "pageInputIconGenerateNewAlias": {
         "message": "Generate New Alias"
     },
+    "pageInputIconGenerateNewAlias_mask": {
+        "message": "Generate new mask"
+    },
     "pageInputIconGetUnlimitedAliases": {
         "message": "Get Unlimited Aliases"
+    },
+    "pageInputIconGetUnlimitedAliases_mask": {
+        "message": "Get unlimited masks"
     },
     "pageInputIconUseExistingAliasFromTheSite": {
         "message": "Use Existing Alias from this Site…"
     },
+    "pageInputIconUseExistingAliasFromTheSite_mask": {
+        "message": "Use existing mask from this site…"
+    },
     "pageInputIconRecentAliases": {
         "message": "Recent Aliases"
+    },
+    "pageInputIconRecentAliases_mask": {
+        "message": "Recent masks"
     },
     "pageInputIconMaxAliasesError": {
         "message": "You have already created the maximum number of aliases",
         "description": "Tells the user they have already created the max number of aliases."
     },
+    "pageInputIconMaxAliasesError_mask": {
+        "message": "You have already created the maximum number of masks",
+        "description": "Tells the user they have already created the max number of masks."
+    },
     "pageFillRelayAddressLimit": {
         "message": "You’ve reached the alias limit."
     },
+    "pageFillRelayAddressLimit_mask": {
+        "message": "You’ve reached the mask limit."
+    },
     "profilePageInvalidAliasCharactersError": {
         "message": "Character(s) not allowed: $CHARACTERS$",
-        "description": "Error message that appears when the user tries to use special characters when labelling an alias.",
+        "description": "Error message that appears when the user tries to use special characters when labelling an mask.",
         "placeholders": {
             "characters": {
                 "content": "$1",
@@ -196,7 +270,7 @@
     },
     "profilePageDefaulAliasLabelText": {
         "message": "Add account name",
-        "description": "On the user's profile page, this text appears for an alias when it doesn't have a label."
+        "description": "On the user's profile page, this text appears for a mask when it doesn't have a label."
     },
     "close": {
         "message": "Close"
@@ -206,6 +280,10 @@
     },
     "popupDataCollectionBody": {
         "message": "You can allow Relay to collect optional data that allows us to sync your alias labels across your devices with the websites where they’re created and used.",
+        "description": "DO NOT TRANSLATE \"Relay\"."
+    },
+    "popupDataCollectionBody_mask": {
+        "message": "You can allow Relay to collect optional data that allows us to sync your mask labels across your devices with the websites where they’re created and used.",
         "description": "DO NOT TRANSLATE \"Relay\"."
     },
     "popupDataCollectionButtonLearnMore": {


### PR DESCRIPTION
These string updates are part of the same effort as https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/66. 

Note that the previous strings will be removed after this merges in. (Maintaining fallback strings) 