### PR TITLE
Add Report Success state strings

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -93,6 +93,13 @@
     "popupReportIssueCaseOtherDetails": {
         "message": "Please provide details"
     },
+    "popupReportIssueSuccessHeadline": {
+        "message": "Report Sent!"
+    },
+    "popupReportIssueSuccessBody": {
+        "message": "Thank you for helping us to improve Firefox Relay!",
+        "description": "DO NOT TRANSLATE \"Firefox Relay\"."
+    },
     "popupSignUpPanelWelcome": {
         "message": "Welcome"
     },

--- a/en/messages.json
+++ b/en/messages.json
@@ -100,6 +100,9 @@
         "message": "Thank you for helping us to improve Firefox Relay!",
         "description": "DO NOT TRANSLATE \"Firefox Relay\"."
     },
+    "popupReportIssueSuccessContinue": {
+        "message": "Continue"
+    },
     "popupSignUpPanelWelcome": {
         "message": "Welcome"
     },


### PR DESCRIPTION
Design spec:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/13066134/181305853-94284869-2fe8-4d37-9496-e6559b6119b3.png">

Would it be fine to reuse the message component:
```
 "popupSignUpPanelContinue": {
        "message": "Continue"
    },

```
for a single word string? Or should I create a duplicate for the context of the feature I'm working on?