### PR TITLE
Add End to Intro Pricing Strings

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -245,6 +245,32 @@
         "message": "Firefox Relay can now forward emails up to 25MB, including attachments.",
         "description": "DO NOT TRANSLATE \"Firefox Relay\"."
     },
+    "popupEndOfIntroPricingHeadline": {
+        "message": "Our intro pricing offer ends soon!"
+    },
+    "popupEndOfIntroPricingBody": {
+        "message": "Get Relay Premium before September 27th and enjoy unlimited masking at our introductory month-to-month price.",
+        "description": "DO NOT TRANSLATE \"Relay Premium\"."
+    },
+    "popupEndOfIntroPricingCTA": {
+        "message": "Upgrade now"
+    },
+    "popupEndOfIntroPricingCountdownDays": {
+        "message": "Days",
+        "description": "This label displayed on top of a large number representing the number of days of the remaining time the introductory pricing offer is still valid. Please abbreviate if the word exceeds 5 characters."
+    },
+    "popupEndOfIntroPricingCountdownHours": {
+        "message": "Hours",
+        "description": "This label displayed on top of a large number representing the number of hours of the remaining time the introductory pricing offer is still valid. Please abbreviate if the word exceeds 5 characters."
+    },
+    "popupEndOfIntroPricingCountdownMinuites": {
+        "message": "Min.",
+        "description": "This label displayed on top of a large number representing the number of minutes of the remaining time the introductory pricing offer is still valid. There's not much room for this, hence the abbreviation."
+    },
+    "popupEndOfIntroPricingCountdownSeconds": {
+        "message": "Sec.",
+        "description": "This label displayed on top of a large number representing the number of seconds of the remaining time the introductory pricing offer is still valid. There's not much room for this, hence the abbreviation."
+    },
     "popupCriticalEmailForwardingHeadline": {
         "message": "Critical email forwarding"
     },


### PR DESCRIPTION
Preview:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/13066134/187228955-9b12fae1-70ef-453a-b1de-7892cb4582ed.png">


Note I added some abbreviated strings here and recommendations to add abbreviations due to the design spec proposed. Let me know if this is the right approach.