### PR TITLE
Fix variables syntax

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -298,21 +298,23 @@
         "message": "With Relay Premium, you can block promotional emails from reaching your inbox while still allowing you to receive emails like receipts or shipping information.",
         "description": "DO NOT TRANSLATE \"Relay Premium\"."
     },
-    "popupBundlePromoHeadline": {
+    "popupBundlePromoHeadline_2": {
         "message": "Add Mozilla VPN at $SAVINGS$ off.",
         "description": "DO NOT TRANSLATE \"Mozilla VPN\"",
         "placeholders": {
             "savings": {
-                "content": "50%"
+                "content": "$1",
+                "example": "50%"
             }
         }
     },
-    "popupBundlePromoBody": {
+    "popupBundlePromoBody_2": {
         "message": "1 year plan including Relay Premium + Mozilla VPN for $MONTHLY_PRICE$/month.",
         "description": "DO NOT TRANSLATE \"Relay Premium\" and \"Mozilla VPN\"",
         "placeholders": {
             "monthly_price": {
-                "content": "$4.99"
+                "content": "$1",
+                "example": "$4.99"
             }
         }
     },


### PR DESCRIPTION
Hi @peiying2, sorry but the syntax for yesterday's PR was off based on the `getMessage` documentation [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage). I ran into issues implementing it yesterday, which was how I realized my error. Sorry about that.