### PR TITLE
Updating strings to reflect non-premium v. premium announcement views (Bundle + Phone masking)

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -346,6 +346,9 @@
     "popupPhoneMaskingPromoBody": {
         "message": "With phone number masking, you can now create a phone number mask that helps you get texts and calls without revealing your true number."
     },
+    "popupPhoneMaskingPromoBodyFreePlan": {
+        "message": "Get texts and calls without revealing your true number."
+    },
     "popupPhoneMaskingPromoCTA": {
         "message": "Upgrade now"
     },

--- a/en/messages.json
+++ b/en/messages.json
@@ -343,10 +343,10 @@
     "popupPhoneMaskingPromoHeadline": {
         "message": "Introducing phone number masking"
     },
-    "popupPhoneMaskingPromoBody": {
+    "popupPhoneMaskingPromoBodyFreePlan": {
         "message": "With phone number masking, you can now create a phone number mask that helps you get texts and calls without revealing your true number."
     },
-    "popupPhoneMaskingPromoBodyFreePlan": {
+    "popupPhoneMaskingPromoBody": {
         "message": "Get texts and calls without revealing your true number."
     },
     "popupPhoneMaskingPromoCTA": {

--- a/en/messages.json
+++ b/en/messages.json
@@ -343,10 +343,10 @@
     "popupPhoneMaskingPromoHeadline": {
         "message": "Introducing phone number masking"
     },
-    "popupPhoneMaskingPromoBodyFreePlan": {
+    "popupPhoneMaskingPromoBody": {
         "message": "With phone number masking, you can now create a phone number mask that helps you get texts and calls without revealing your true number."
     },
-    "popupPhoneMaskingPromoBody": {
+    "popupPhoneMaskingPromoBodyPremium": {
         "message": "Get texts and calls without revealing your true number."
     },
     "popupPhoneMaskingPromoCTA": {

--- a/en/messages.json
+++ b/en/messages.json
@@ -318,6 +318,24 @@
             }
         }
     },
+    "popupBundlePromoHeadlineFreePlan": {
+        "message": "Introducing: Relay + VPN subscription plan",
+        "description" : "\"Relay\" and \"VPN\"."
+    },
+    "popupBundlePromoBodyFreePlan": {
+        "message": "Upgrade your subscription to get both Relay Premium + Mozilla VPN for $MONTHLY_PRICE$/month. Save $SAVINGS$!",
+        "description": "DO NOT TRANSLATE \"Relay Premium\" and \"Mozilla VPN\". This string includes a monthly price variable, e.g. $4.99. It also includes a savings variable, e.g. 50%",
+        "placeholders": {
+            "monthly_price": {
+                "content": "$1",
+                "example": "$4.99"
+            },
+            "savings": {
+                "content": "$2",
+                "example": "50%"
+            }
+        }
+    },
     "popupBundlePromoCTA": {
         "message": "Get VPN + Relay",
         "description": "DO NOT TRANSLATE \"VPN\" and \"Relay\""

--- a/en/messages.json
+++ b/en/messages.json
@@ -320,7 +320,7 @@
     },
     "popupBundlePromoHeadlineFreePlan": {
         "message": "Introducing: Relay + VPN subscription plan",
-        "description" : "\"Relay\" and \"VPN\"."
+        "description": "DO NOT TRANSLATE \"Relay\" and \"VPN\"."
     },
     "popupBundlePromoBodyFreePlan": {
         "message": "Upgrade your subscription to get both Relay Premium + Mozilla VPN for $MONTHLY_PRICE$/month. Save $SAVINGS$!",


### PR DESCRIPTION
I just spoke with Eduardo about the different views for the promo determined by premium status. Turns out the strings are different between free and premium users. Apologies for the continuous changes.