### PR TITLE
Add string to prefill a phone number mask

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -438,6 +438,9 @@
     "pageInputIconRecentAliases_mask": {
         "message": "Recent masks"
     },
+    "pageInputIconInsertPhoneMask": {
+        "message": "Use phone number mask"
+    },
     "pageInputIconMaxAliasesError": {
         "message": "You have already created the maximum number of aliases",
         "description": "Tells the user they have already created the max number of aliases."


### PR DESCRIPTION
Companion to https://github.com/mozilla/fx-private-relay-add-on/pull/433

![image](https://user-images.githubusercontent.com/4251/201345581-725a8ef9-d39f-42d2-bba3-4eea85a0e366.png)
